### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/home/.local/bin/doi2bib
+++ b/home/.local/bin/doi2bib
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-bibtex="$(curl -sfLH "Accept: application/x-bibtex;q=1" "http://dx.doi.org/$1")"
+bibtex="$(curl -sfLH "Accept: application/x-bibtex;q=1" "https://doi.org/$1")"
 if [[ $? -eq 0 ]]; then
     if [[ "$(uname)" = "Darwin" ]]; then
         echo "$bibtex" | pbcopy


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates the code that generates new DOI links.

Cheers!